### PR TITLE
Optional Parameters

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -81,10 +81,6 @@ function needsSignature(doclet) {
 function getSignatureAttributes(item) {
     var attributes = [];
 
-    if (item.optional) {
-        attributes.push('opt');
-    }
-
     if (item.nullable === true) {
         attributes.push('nullable');
     }
@@ -95,7 +91,7 @@ function getSignatureAttributes(item) {
     return attributes;
 }
 
-function updateItemName(item) {
+function updateItemName(item, index) {
     var attributes = getSignatureAttributes(item);
     var itemName = item.name || '';
 
@@ -106,6 +102,13 @@ function updateItemName(item) {
     if (attributes && attributes.length) {
         itemName = util.format( '%s<span class="signature-attributes">%s</span>', itemName,
             attributes.join(', ') );
+    }
+
+    if (index !== 0) {
+        itemName = util.format(', %s', itemName );
+    }
+    if (item.optional) {
+      itemName = util.format('\[%s\]', itemName );
     }
 
     return itemName;
@@ -152,7 +155,7 @@ function addNonParamAttributes(items) {
 function addSignatureParams(f) {
     var params = f.params ? addParamAttributes(f.params) : [];
 
-    f.signature = util.format( '%s(%s)', (f.signature || ''), params.join(', ') );
+    f.signature = util.format( '%s(%s)', (f.signature || ''), params.join('') );
 }
 
 function addSignatureReturns(f) {

--- a/stylesheets/jsdoc.css
+++ b/stylesheets/jsdoc.css
@@ -16,3 +16,8 @@ h2 + h4.name, h3.subsection-title + h4.name {
 h2 + h4.name {
   padding-top: 0.1em;
 }
+
+.optional {
+  font-size: 0.8em;
+  font-style: italic;
+}

--- a/tmpl/params.tmpl
+++ b/tmpl/params.tmpl
@@ -43,7 +43,7 @@
     params.forEach(function(param) {
         if (!param) { return; }
 
-        if (param.optional || param.nullable || param.variable) {
+        if (param.nullable || param.variable) {
             params.hasAttributes = true;
         }
 
@@ -87,7 +87,9 @@
 
         <tr>
             <?js if (params.hasName) {?>
-                <td class="name" style="white-space:nowrap;"><code><?js= param.name ?></code></td>
+                <td class="name" style="white-space:nowrap;"><code><?js= param.name ?></code>
+                <?js if (param.optional) { ?><br><span class="optional">Optional</span><?js } ?>
+                </td>
             <?js } ?>
 
             <td class="type">
@@ -98,10 +100,6 @@
 
             <?js if (params.hasAttributes) {?>
                 <td class="attributes">
-                <?js if (param.optional) { ?>
-                    &lt;optional><br>
-                <?js } ?>
-
                 <?js if (param.nullable) { ?>
                     &lt;nullable><br>
                 <?js } ?>


### PR DESCRIPTION
This PR makes a few changes that simplify how we show optional parameters in our docs.

## Signatures:
_After:_
<img width="330" alt="screen shot 2017-10-30 at 10 58 40 am" src="https://user-images.githubusercontent.com/10263364/32187156-58b51868-bd61-11e7-835e-015a6cff694b.png">

_Before:_
<img width="342" alt="screen shot 2017-10-30 at 10 58 48 am" src="https://user-images.githubusercontent.com/10263364/32187166-5e023d1e-bd61-11e7-9d1b-dbbb426442e7.png">


## Param Table:
_After:_
<img width="1210" alt="screen shot 2017-11-03 at 10 00 16 am" src="https://user-images.githubusercontent.com/10263364/32386271-d4b0867c-c07d-11e7-91f6-b8649e43f14e.png">


_Before:_ 
<img width="1143" alt="screen shot 2017-10-30 at 10 43 58 am" src="https://user-images.githubusercontent.com/10263364/32187123-40a57c90-bd61-11e7-9026-1e6cebf0ad94.png">


